### PR TITLE
Change to use Microsoft.App instead of Microsoft.Web namespace

### DIFF
--- a/with-fqdn/README.md
+++ b/with-fqdn/README.md
@@ -16,6 +16,7 @@ res.send(`${JSON.stringify(data.data)}`);
 az login
 az extension add \
   --source https://workerappscliextension.blob.core.windows.net/azure-cli-extension/containerapp-0.2.0-py2.py3-none-any.whl
+az extension add -n containerapp
 az provider register --namespace Microsoft.App
 
 # Create a resource group

--- a/with-fqdn/README.md
+++ b/with-fqdn/README.md
@@ -16,7 +16,7 @@ res.send(`${JSON.stringify(data.data)}`);
 az login
 az extension add \
   --source https://workerappscliextension.blob.core.windows.net/azure-cli-extension/containerapp-0.2.0-py2.py3-none-any.whl
-az provider register --namespace Microsoft.Web
+az provider register --namespace Microsoft.App
 
 # Create a resource group
 az group create \


### PR DESCRIPTION
Creation or update of environments with type managed in Microsoft.Web namespace is no longer supported. Please use Microsoft.App namespace instead. More information available via aka.ms/microsoftappmigration.

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->